### PR TITLE
feat: RK3588: pin gstreamer1.0-plugins-good to debian repo

### DIFF
--- a/apt/radxa-rk3588
+++ b/apt/radxa-rk3588
@@ -32,33 +32,5 @@ Pin-Priority: 1001
 
 # v4l2src is part of gstreamer1.0-plugins-good
 Package: gstreamer1.0-plugins-good
-Pin: release a=rk3582-bookworm
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3582-bookworm-test
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588s-bookworm
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588s-bookworm-test
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588s2-bookworm
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588s2-bookworm-test
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588-bookworm
-Pin-Priority: 1001
-
-Package: gstreamer1.0-plugins-good
-Pin: release a=rk3588-bookworm-test
+Pin: release a=stable
 Pin-Priority: 1001


### PR DESCRIPTION
在最新的镜像中，想要正常使用cheese预览摄像头，需要将gstreamer1.0-plugins-good降低版本，使用stable的deb
这样操作，gstreamer 会取消掉 min-buffers 的参数支持
这样修改验证264 265编解码正常，没有出现#7 的情况