### PR TITLE
fix: rk356x: remove dependency libmali

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -253,7 +253,6 @@ Priority: optional
 Depends: task-rockchip,
          radxa-system-config-rockchip-glamor,
          task-rk356x-camera,
-         libmali-bifrost-g52-g13p0-x11-gbm,
          rknpu2-rk356x,
          python3-rknnlite2,
          ${misc:Depends},


### PR DESCRIPTION
rk356x now using panforst