### PR TITLE
feat: rk3399: add radxa-system-config-rockchip depend

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -194,6 +194,7 @@ Package: task-rk3399
 Architecture: all
 Priority: optional
 Depends: task-rockchip,
+         radxa-system-config-rockchip,
          radxa-system-config-rockchip-glamor,
          task-rk3399-camera,
          libmali-midgard-t86x-r18p0-x11 | libmali-midgard-t86x-r18p0-x11-gbm,


### PR DESCRIPTION
The panfrost gpu driver is going to be used by default[[0]]. Running wayland with the panfrost gpu driver causes some issues: the malfunction of gdm background display, showing only black screen after logging in, and outputing `rockchip-vop ff900000.vop: [drm:vop_isr] *ERROR* POST_BUF_EMPTY irq err` at the serial console. The package `radxa-system-config-rockchip` will affect the settings of `gdm` so `x11` is used by default.

[0]: https://github.com/radxa/kernel/pull/436