### PR TITLE
fix: rk3399: remove dependency libmali

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -196,7 +196,6 @@ Priority: optional
 Depends: task-rockchip,
          radxa-system-config-rockchip-glamor,
          task-rk3399-camera,
-         libmali-midgard-t86x-r18p0-x11 | libmali-midgard-t86x-r18p0-x11-gbm,
          radxa-system-config-rk3399,
          ${misc:Depends},
 Description: Metapackages for common RK3399 vendor packages


### PR DESCRIPTION
Otherwise the panfrost gpu driver will not be used.