### PR TITLE
fix: update gstreamer1.0-plugins-good apt config

### DIFF
--- a/apt/radxa-rk3399
+++ b/apt/radxa-rk3399
@@ -25,5 +25,5 @@ Pin-Priority: 1001
 
 # v4l2src is part of gstreamer1.0-plugins-good
 Package: gstreamer1.0-plugins-good
-Pin: release a=stable
+Pin: release o=Debian, l=Debian
 Pin-Priority: 1001

--- a/apt/radxa-rk356x
+++ b/apt/radxa-rk356x
@@ -17,5 +17,5 @@ Pin-Priority: 1001
 
 # v4l2src is part of gstreamer1.0-plugins-good
 Package: gstreamer1.0-plugins-good
-Pin: release a=stable
+Pin: release o=Debian, l=Debian
 Pin-Priority: 1001

--- a/apt/radxa-rk3588
+++ b/apt/radxa-rk3588
@@ -33,5 +33,5 @@ Pin-Priority: 1001
 
 # v4l2src is part of gstreamer1.0-plugins-good
 Package: gstreamer1.0-plugins-good
-Pin: release a=stable
+Pin: release o=Debian, l=Debian
 Pin-Priority: 1001


### PR DESCRIPTION
```

    fix: update gstreamer1.0-plugins-good apt config
    
    In the last Debian update[0], the bookworm repos changed from stable to
    oldstable, which caused the original pinning config of
    gstreamer1.0-plugins-good to stop working. To fix this issue and avoid
    the same fix in the future, this change modifies the pinning config of
    gstreamer1.0-plugins-good, so apt prefers the gstreamer1.0-plugins-good
    package from Debian.
    
    [0]: https://www.debian.org/News/2025/20250809
    
    Signed-off-by: Zhaoming Luo <luozhaoming@radxa.com>
```